### PR TITLE
12 Force gradle tag to 7.6.1-jdk8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN curl -L https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -o 
 
 # build jar with gradle
 
-FROM gradle:jdk8 as gradle-build
+FROM gradle:7.6.1-jdk8 as gradle-build
 
 WORKDIR /home/gradle/project
 


### PR DESCRIPTION
Fix for build error `java.lang.NoSuchMethodError: org.gradle.api.artifacts.dsl.DependencyHandler.registerTransform`